### PR TITLE
updater cron job: rm update on merge to main

### DIFF
--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -1,7 +1,5 @@
 name: Update Dependencies
 on:
-  push:
-    branches: [ "main" ]
   # every monday at 10 AM
   schedule:
   - cron:  '0 10 * * 1'


### PR DESCRIPTION
a weekly cadence will do just fine.  we don't need to run update on every push to main.